### PR TITLE
Remove bundled Kaggle credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Ignore Python virtual environment
+venv/
+# Ignore Kaggle credentials
+kaggle.json
+**/kaggle.json
+**/.kaggle/

--- a/README.md
+++ b/README.md
@@ -18,10 +18,12 @@ Le cluster est constitué de trois conteneurs Docker :
 ## 🚀 Installation et Démarrage  
 
 ### 1️⃣ Prérequis  
-Avant de commencer, assurez-vous d'avoir :  
-- **WSL2 + Ubuntu** installé sous Windows  
-- **Docker Desktop** configuré avec WSL  
-- **Kaggle CLI** installé (`pip install kaggle`)  
+Avant de commencer, assurez-vous d'avoir :
+- **WSL2 + Ubuntu** installé sous Windows
+- **Docker Desktop** configuré avec WSL
+- **Kaggle CLI** installé (`pip install kaggle`)
+- Des identifiants Kaggle disponibles via un fichier `~/.kaggle/kaggle.json` ou
+  les variables d'environnement `KAGGLE_USERNAME` et `KAGGLE_KEY`
 
 ### 2️⃣ Démarrer le cluster Hadoop  
 ```bash  
@@ -35,8 +37,10 @@ docker ps
 ```  
 Vous devriez voir `namenode`, `datanode1` et `datanode2` en cours d'exécution.  
 
-### 4️⃣ Charger les bases de données Kaggle  
-Lancer le script d'importation :  
+### 4️⃣ Charger les bases de données Kaggle
+Assurez-vous que vos identifiants Kaggle sont disponibles (fichier `kaggle.json`
+monté dans le conteneur ou variables `KAGGLE_USERNAME` et `KAGGLE_KEY`).
+Lancer ensuite le script d'importation :
 ```bash  
 chmod +x load_db_kaggle.sh  
 ./load_db_kaggle.sh  

--- a/data-loader/Dockerfile
+++ b/data-loader/Dockerfile
@@ -25,10 +25,12 @@ ENV PATH=$JAVA_HOME/bin:$PATH
 # 🔹 Préparer les dossiers
 RUN mkdir -p /datasets/text /datasets/images
 
-# 🔹 Ajouter le script + credentials Kaggle
+# 🔹 Ajouter le script
 COPY load_db_hdfs.sh .
-COPY kaggle.json /root/.kaggle/kaggle.json
-RUN chmod 600 /root/.kaggle/kaggle.json
 RUN chmod +x load_db_hdfs.sh
+
+# 🔹 Préparer le dossier de configuration Kaggle
+ENV KAGGLE_CONFIG_DIR=/root/.kaggle
+RUN mkdir -p "$KAGGLE_CONFIG_DIR"
 
 CMD ["./load_db_hdfs.sh"]

--- a/data-loader/kaggle.json
+++ b/data-loader/kaggle.json
@@ -1,1 +1,0 @@
-{"username":"squalala","key":"ae3c1199e943ec4f17508408cb7d3656"}

--- a/data-loader/load_db_hdfs.sh
+++ b/data-loader/load_db_hdfs.sh
@@ -116,13 +116,23 @@ fi
 # === NOUVEAU: Téléchargement de bases de données existantes ===
 echo "📥 === TÉLÉCHARGEMENT DE BASES DE DONNÉES EXISTANTES ==="
 
+# Configurer Kaggle si les variables d'environnement sont présentes
+if [ ! -f "/root/.kaggle/kaggle.json" ] && [ -n "$KAGGLE_USERNAME" ] && [ -n "$KAGGLE_KEY" ]; then
+    echo "⚙️ Création du fichier de configuration Kaggle à partir des variables d'environnement..."
+    mkdir -p /root/.kaggle
+    cat > /root/.kaggle/kaggle.json <<EOF
+{"username":"$KAGGLE_USERNAME","key":"$KAGGLE_KEY"}
+EOF
+    chmod 600 /root/.kaggle/kaggle.json
+fi
+
 # Vérifier si Kaggle est configuré
-if [ ! -f "/root/.kaggle/kaggle.json" ]; then
-    echo "⚠️ Kaggle non configuré, création de données de test à la place..."
-    USE_KAGGLE=false
-else
+if [ -f "/root/.kaggle/kaggle.json" ]; then
     echo "✅ Kaggle configuré, téléchargement des datasets..."
     USE_KAGGLE=true
+else
+    echo "⚠️ Kaggle non configuré, création de données de test à la place..."
+    USE_KAGGLE=false
 fi
 
 if [ "$USE_KAGGLE" = true ]; then


### PR DESCRIPTION
## Summary
- stop shipping `kaggle.json`
- load Kaggle credentials from env vars
- ignore Kaggle secrets via `.gitignore`
- document the new credential approach

## Testing
- `pytest -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'hdfs')*

------
https://chatgpt.com/codex/tasks/task_e_685b2b7a878c832f87d0a1963f5e4eb5